### PR TITLE
Read APC NMC status through SSH shell connection

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         minSdkVersion 22
         targetSdkVersion 30
 
-        versionCode 36
-        versionName "1.11.0" // Use Semver
+        versionCode 37
+        versionName "1.12.0" // Use Semver
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/app/src/main/java/com/nitramite/apcupsdmonitor/ConnectorTask.java
+++ b/app/src/main/java/com/nitramite/apcupsdmonitor/ConnectorTask.java
@@ -39,6 +39,7 @@ public class ConnectorTask extends AsyncTask<String, String, String> {
 
     // Command variables
     private String statusCommand = Constants.STATUS_COMMAND_APCUPSD;
+    private boolean isApcNmc = false;
     private String eventsLocation = Constants.EVENTS_LOCATION;
 
     // Variables
@@ -115,6 +116,7 @@ public class ConnectorTask extends AsyncTask<String, String, String> {
             final String connectionType = upsArrayList.get(arrayPosition).UPS_CONNECTION_TYPE;
 
             this.statusCommand = upsArrayList.get(arrayPosition).UPS_SERVER_STATUS_COMMAND;
+            this.isApcNmc = upsArrayList.get(arrayPosition).IS_APC_NMC;
             this.eventsLocation = upsArrayList.get(arrayPosition).UPS_SERVER_EVENTS_LOCATION;
             this.address = upsArrayList.get(arrayPosition).UPS_SERVER_ADDRESS;
             this.port = portStringToInteger(upsArrayList.get(arrayPosition).UPS_SERVER_PORT);

--- a/app/src/main/java/com/nitramite/apcupsdmonitor/ConnectorTask.java
+++ b/app/src/main/java/com/nitramite/apcupsdmonitor/ConnectorTask.java
@@ -39,7 +39,6 @@ public class ConnectorTask extends AsyncTask<String, String, String> {
 
     // Command variables
     private String statusCommand = Constants.STATUS_COMMAND_APCUPSD;
-    private boolean isApcNmc = false;
     private String eventsLocation = Constants.EVENTS_LOCATION;
 
     // Variables
@@ -117,7 +116,6 @@ public class ConnectorTask extends AsyncTask<String, String, String> {
             final String connectionType = ups.UPS_CONNECTION_TYPE;
 
             this.statusCommand = ups.UPS_SERVER_STATUS_COMMAND;
-            this.isApcNmc = ups.IS_APC_NMC;
             this.eventsLocation = ups.UPS_SERVER_EVENTS_LOCATION;
             this.address = ups.UPS_SERVER_ADDRESS;
             this.port = portStringToInteger(ups.UPS_SERVER_PORT);
@@ -151,7 +149,7 @@ public class ConnectorTask extends AsyncTask<String, String, String> {
                 // SSH
                 if (validSSHRequirements()) {
                     if (connectSSHServer(ups.UPS_ID)) {
-                        if (ups.IS_APC_NMC) {
+                        if (ups.UPS_IS_APC_NMC) {
                             getUPSStatusNMC(ups.UPS_ID);
                         } else {
                             getUPSStatusSSH(ups.UPS_ID, ups.getUpsLoadEvents());

--- a/app/src/main/java/com/nitramite/apcupsdmonitor/ConnectorTask.java
+++ b/app/src/main/java/com/nitramite/apcupsdmonitor/ConnectorTask.java
@@ -113,36 +113,36 @@ public class ConnectorTask extends AsyncTask<String, String, String> {
                 apcupsdInterface.onRefreshList(); // Refresh list view
             }
 
-            final String connectionType = upsArrayList.get(arrayPosition).UPS_CONNECTION_TYPE;
+            UPS ups = upsArrayList.get(arrayPosition);
+            final String connectionType = ups.UPS_CONNECTION_TYPE;
 
-            this.statusCommand = upsArrayList.get(arrayPosition).UPS_SERVER_STATUS_COMMAND;
-            this.isApcNmc = upsArrayList.get(arrayPosition).IS_APC_NMC;
-            this.eventsLocation = upsArrayList.get(arrayPosition).UPS_SERVER_EVENTS_LOCATION;
-            this.address = upsArrayList.get(arrayPosition).UPS_SERVER_ADDRESS;
-            this.port = portStringToInteger(upsArrayList.get(arrayPosition).UPS_SERVER_PORT);
-            this.sshUsername = upsArrayList.get(arrayPosition).UPS_SERVER_USERNAME;
-            this.sshPassword = upsArrayList.get(arrayPosition).UPS_SERVER_PASSWORD;
-            this.strictHostKeyChecking = upsArrayList.get(arrayPosition).UPS_SERVER_SSH_STRICT_HOST_KEY_CHECKING.equals("1");
+            this.statusCommand = ups.UPS_SERVER_STATUS_COMMAND;
+            this.isApcNmc = ups.IS_APC_NMC;
+            this.eventsLocation = ups.UPS_SERVER_EVENTS_LOCATION;
+            this.address = ups.UPS_SERVER_ADDRESS;
+            this.port = portStringToInteger(ups.UPS_SERVER_PORT);
+            this.sshUsername = ups.UPS_SERVER_USERNAME;
+            this.sshPassword = ups.UPS_SERVER_PASSWORD;
+            this.strictHostKeyChecking = ups.UPS_SERVER_SSH_STRICT_HOST_KEY_CHECKING.equals("1");
 
-            this.sshHostName = upsArrayList.get(arrayPosition).UPS_SERVER_HOST_NAME;
-            this.sshHostFingerPrint = upsArrayList.get(arrayPosition).UPS_SERVER_HOST_FINGER_PRINT;
-            this.sshHostKey = upsArrayList.get(arrayPosition).UPS_SERVER_HOST_KEY;
+            this.sshHostName = ups.UPS_SERVER_HOST_NAME;
+            this.sshHostFingerPrint = ups.UPS_SERVER_HOST_FINGER_PRINT;
+            this.sshHostKey = ups.UPS_SERVER_HOST_KEY;
 
             // Private key feature
-            this.privateKeyFileEnabled = upsArrayList.get(arrayPosition).UPS_USE_PRIVATE_KEY_AUTH.equals("1");
-            this.privateKeyFilePassphrase = upsArrayList.get(arrayPosition).UPS_PRIVATE_KEY_PASSWORD;
-            this.privateKeyFileLocation = upsArrayList.get(arrayPosition).UPS_PRIVATE_KEY_PATH;
+            this.privateKeyFileEnabled = ups.UPS_USE_PRIVATE_KEY_AUTH.equals("1");
+            this.privateKeyFilePassphrase = ups.UPS_PRIVATE_KEY_PASSWORD;
+            this.privateKeyFileLocation = ups.UPS_PRIVATE_KEY_PATH;
 
 
             // Determine connection type
             if (connectionType.equals(UPS.UPS_CONNECTION_TYPE_NIS)) {
                 // APCUPSD SOCKET
                 if (validAPCUPSDRequirements()) {
-                    if (connectSocketServer(upsArrayList.get(arrayPosition).UPS_ID, this.address, this.port)) {
-                        getUPSStatusAPCUPSD(upsArrayList.get(arrayPosition).UPS_ID,
-                                upsArrayList.get(arrayPosition).getUpsLoadEvents());
+                    if (connectSocketServer(ups.UPS_ID, this.address, this.port)) {
+                        getUPSStatusAPCUPSD(ups.UPS_ID, ups.getUpsLoadEvents());
                     } else {
-                        onConnectionError(upsArrayList.get(arrayPosition).UPS_ID);
+                        onConnectionError(ups.UPS_ID);
                     }
                 } else {
                     apcupsdInterface.onMissingPreferences();
@@ -150,11 +150,10 @@ public class ConnectorTask extends AsyncTask<String, String, String> {
             } else if (connectionType.equals(UPS.UPS_CONNECTION_TYPE_SSH)) {
                 // SSH
                 if (validSSHRequirements()) {
-                    if (connectSSHServer(upsArrayList.get(arrayPosition).UPS_ID)) {
-                        getUPSStatusSSH(upsArrayList.get(arrayPosition).UPS_ID,
-                                upsArrayList.get(arrayPosition).getUpsLoadEvents());
+                    if (connectSSHServer(ups.UPS_ID)) {
+                        getUPSStatusSSH(ups.UPS_ID, ups.getUpsLoadEvents());
                     } else {
-                        onConnectionError(upsArrayList.get(arrayPosition).UPS_ID);
+                        onConnectionError(ups.UPS_ID);
                     }
                 } else {
                     apcupsdInterface.onMissingPreferences();

--- a/app/src/main/java/com/nitramite/apcupsdmonitor/DatabaseHelper.java
+++ b/app/src/main/java/com/nitramite/apcupsdmonitor/DatabaseHelper.java
@@ -29,6 +29,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     // 1 = v1.1.5
     // 2 = v1.2.2, added ups load events boolean
     // 3 = v1.8.7, added ups_reachable boolean
+    // 4 = v1.12.0, contributor bo0tzz added is_apc_nmc field
 
 
     // DATABASE NAME

--- a/app/src/main/java/com/nitramite/apcupsdmonitor/DatabaseHelper.java
+++ b/app/src/main/java/com/nitramite/apcupsdmonitor/DatabaseHelper.java
@@ -25,7 +25,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     private boolean upgrade = false;
 
     // DATABASE VERSION
-    private static final int DATABASE_VERSION = 3;
+    private static final int DATABASE_VERSION = 4;
     // 1 = v1.1.5
     // 2 = v1.2.2, added ups load events boolean
     // 3 = v1.8.7, added ups_reachable boolean
@@ -52,6 +52,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     static final String UPS_PRIVATE_KEY_PATH = "server_private_key_path";
     static final String UPS_SERVER_SSH_STRICT_HOST_KEY_CHECKING = "server_strict_host_key_checking";
     static final String UPS_SERVER_STATUS_COMMAND = "server_status_command";
+    static final String IS_APC_NMC = "is_apc_nmc";
     static final String UPS_SERVER_EVENTS_LOCATION = "server_events_location";
     static final String UPS_SERVER_HOST_NAME = "server_host_name";
     static final String UPS_SERVER_HOST_FINGER_PRINT = "server_host_finger_print";
@@ -93,7 +94,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
         db.execSQL("CREATE TABLE IF NOT EXISTS " + UPS_TABLE + "(id INTEGER PRIMARY KEY AUTOINCREMENT, ups_connection_type TEXT, server_address TEXT, server_port TEXT, server_username TEXT, " +
                 "server_password TEXT, server_use_private_key_auth TEXT, server_private_key_password TEXT, server_private_key_path TEXT, server_strict_host_key_checking TEXT, " +
                 "server_status_command TEXT, server_events_location TEXT, server_host_name TEXT, server_host_finger_print TEXT, server_host_key TEXT, " +
-                "ups_status_str TEXT, ups_load_events TEXT, ups_reachable TEXT)");
+                "ups_status_str TEXT, ups_load_events TEXT, ups_reachable TEXT, is_apc_nmc INTEGER)");
 
         // Create events data table
         db.execSQL("CREATE TABLE IF NOT EXISTS " + EVENTS_TABLE + "(id INTEGER PRIMARY KEY AUTOINCREMENT, ups_id TEXT, event_str TEXT)");
@@ -181,6 +182,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
             ups.setUPS_STATUS_STR(res.getString(15));
             ups.UPS_LOAD_EVENTS = res.getString(16);
             ups.setUPS_REACHABLE_STATUS(res.getString(17));
+            ups.IS_APC_NMC = res.getInt(18) != 0;
             upsArrayList.add(ups);
         }
         res.close();

--- a/app/src/main/java/com/nitramite/apcupsdmonitor/DatabaseHelper.java
+++ b/app/src/main/java/com/nitramite/apcupsdmonitor/DatabaseHelper.java
@@ -52,7 +52,6 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     static final String UPS_PRIVATE_KEY_PATH = "server_private_key_path";
     static final String UPS_SERVER_SSH_STRICT_HOST_KEY_CHECKING = "server_strict_host_key_checking";
     static final String UPS_SERVER_STATUS_COMMAND = "server_status_command";
-    static final String IS_APC_NMC = "is_apc_nmc";
     static final String UPS_SERVER_EVENTS_LOCATION = "server_events_location";
     static final String UPS_SERVER_HOST_NAME = "server_host_name";
     static final String UPS_SERVER_HOST_FINGER_PRINT = "server_host_finger_print";
@@ -60,6 +59,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     static final String UPS_STATUS_STR = "ups_status_str"; // status message containing all lines
     static final String UPS_LOAD_EVENTS = "ups_load_events";
     static final String UPS_REACHABLE = "ups_reachable";
+    static final String UPS_IS_APC_NMC = "is_apc_nmc";
 
     // -------------------------------------------------------------------
 
@@ -182,7 +182,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
             ups.setUPS_STATUS_STR(res.getString(15));
             ups.UPS_LOAD_EVENTS = res.getString(16);
             ups.setUPS_REACHABLE_STATUS(res.getString(17));
-            ups.IS_APC_NMC = res.getInt(18) != 0;
+            ups.UPS_IS_APC_NMC = res.getInt(18) != 0;
             upsArrayList.add(ups);
         }
         res.close();

--- a/app/src/main/java/com/nitramite/apcupsdmonitor/UPS.java
+++ b/app/src/main/java/com/nitramite/apcupsdmonitor/UPS.java
@@ -30,6 +30,7 @@ public class UPS {
     public String UPS_PRIVATE_KEY_PATH = null;
     public String UPS_SERVER_SSH_STRICT_HOST_KEY_CHECKING = null;
     public String UPS_SERVER_STATUS_COMMAND = null;
+    public boolean IS_APC_NMC = false;
     public String UPS_SERVER_EVENTS_LOCATION = null;
     public String UPS_SERVER_HOST_NAME = null;
     public String UPS_SERVER_HOST_FINGER_PRINT = null;

--- a/app/src/main/java/com/nitramite/apcupsdmonitor/UPS.java
+++ b/app/src/main/java/com/nitramite/apcupsdmonitor/UPS.java
@@ -30,12 +30,12 @@ public class UPS {
     public String UPS_PRIVATE_KEY_PATH = null;
     public String UPS_SERVER_SSH_STRICT_HOST_KEY_CHECKING = null;
     public String UPS_SERVER_STATUS_COMMAND = null;
-    public boolean IS_APC_NMC = false;
     public String UPS_SERVER_EVENTS_LOCATION = null;
     public String UPS_SERVER_HOST_NAME = null;
     public String UPS_SERVER_HOST_FINGER_PRINT = null;
     public String UPS_SERVER_HOST_KEY = null;
     public String UPS_LOAD_EVENTS = null;
+    public boolean UPS_IS_APC_NMC = false;
 
     // Variables | status and event strings
     private String UPS_STATUS_STR = null;

--- a/app/src/main/java/com/nitramite/apcupsdmonitor/UpsEditor.java
+++ b/app/src/main/java/com/nitramite/apcupsdmonitor/UpsEditor.java
@@ -102,21 +102,25 @@ public class UpsEditor extends AppCompatActivity {
                         statusCommandET.setText(Constants.STATUS_COMMAND_APCUPSD);
                         loadUpsEventsSwitch.setChecked(true);
                         isApcNmc = false;
+                        statusCommandET.setVisibility(View.VISIBLE);
                         break;
                     case 2:
                         statusCommandET.setText(Constants.STATUS_COMMAND_APCUPSD_NO_SUDO);
                         loadUpsEventsSwitch.setChecked(true);
                         isApcNmc = false;
+                        statusCommandET.setVisibility(View.VISIBLE);
                         break;
                     case 3:
                         statusCommandET.setText(Constants.STATUS_COMMAND_SYNOLOGY);
                         loadUpsEventsSwitch.setChecked(false);
                         isApcNmc = false;
+                        statusCommandET.setVisibility(View.VISIBLE);
                         break;
                     case 4:
                         statusCommandET.setText(Constants.STATUS_COMMAND_APC_NETWORK_CARD);
                         loadUpsEventsSwitch.setChecked(false);
                         isApcNmc = true;
+                        statusCommandET.setVisibility(View.GONE);
                         break;
                 }
             }
@@ -159,6 +163,10 @@ public class UpsEditor extends AppCompatActivity {
             strictHostKeyCheckingSwitch.setChecked(ups.UPS_SERVER_SSH_STRICT_HOST_KEY_CHECKING.equals("1"));
             statusCommandET.setText(ups.UPS_SERVER_STATUS_COMMAND);
             isApcNmc = ups.IS_APC_NMC;
+            if (isApcNmc) {
+                int pos = dataAdapter.getPosition(getString(R.string.apc_network_management_card_aos));
+                cmdPresetSelection.setSelection(pos);
+            }
             eventsLocationET.setText(ups.UPS_SERVER_EVENTS_LOCATION);
             loadUpsEventsSwitch.setChecked(ups.getUpsLoadEvents());
         }

--- a/app/src/main/java/com/nitramite/apcupsdmonitor/UpsEditor.java
+++ b/app/src/main/java/com/nitramite/apcupsdmonitor/UpsEditor.java
@@ -42,6 +42,7 @@ public class UpsEditor extends AppCompatActivity {
     // Variables
     private SharedPreferences sharedPreferences;
     private String upsId = null;
+    private boolean isApcNmc = false;
     private DatabaseHelper databaseHelper = new DatabaseHelper(this);
     private static final int IMPORT_FILE_REQUEST_CODE = 2;
 
@@ -100,18 +101,22 @@ public class UpsEditor extends AppCompatActivity {
                     case 1:
                         statusCommandET.setText(Constants.STATUS_COMMAND_APCUPSD);
                         loadUpsEventsSwitch.setChecked(true);
+                        isApcNmc = false;
                         break;
                     case 2:
                         statusCommandET.setText(Constants.STATUS_COMMAND_APCUPSD_NO_SUDO);
                         loadUpsEventsSwitch.setChecked(true);
+                        isApcNmc = false;
                         break;
                     case 3:
                         statusCommandET.setText(Constants.STATUS_COMMAND_SYNOLOGY);
                         loadUpsEventsSwitch.setChecked(false);
+                        isApcNmc = false;
                         break;
                     case 4:
                         statusCommandET.setText(Constants.STATUS_COMMAND_APC_NETWORK_CARD);
                         loadUpsEventsSwitch.setChecked(false);
+                        isApcNmc = true;
                         break;
                 }
             }
@@ -153,6 +158,7 @@ public class UpsEditor extends AppCompatActivity {
             privateKeyPassphraseET.setText(ups.UPS_PRIVATE_KEY_PASSWORD);
             strictHostKeyCheckingSwitch.setChecked(ups.UPS_SERVER_SSH_STRICT_HOST_KEY_CHECKING.equals("1"));
             statusCommandET.setText(ups.UPS_SERVER_STATUS_COMMAND);
+            isApcNmc = ups.IS_APC_NMC;
             eventsLocationET.setText(ups.UPS_SERVER_EVENTS_LOCATION);
             loadUpsEventsSwitch.setChecked(ups.getUpsLoadEvents());
         }
@@ -193,6 +199,7 @@ public class UpsEditor extends AppCompatActivity {
             contentValues.put(DatabaseHelper.UPS_PRIVATE_KEY_PATH, privateKeyLocationET.getText().toString());
             contentValues.put(DatabaseHelper.UPS_SERVER_SSH_STRICT_HOST_KEY_CHECKING, strictHostKeyCheckingSwitch.isChecked() ? "1" : "0");
             contentValues.put(DatabaseHelper.UPS_SERVER_STATUS_COMMAND, statusCommandET.getText().toString());
+            contentValues.put(DatabaseHelper.IS_APC_NMC, isApcNmc);
             contentValues.put(DatabaseHelper.UPS_SERVER_EVENTS_LOCATION, eventsLocationET.getText().toString());
             contentValues.put(DatabaseHelper.UPS_LOAD_EVENTS, loadUpsEventsSwitch.isChecked() ? "1" : "0");
             databaseHelper.insertUpdateUps(upsId, contentValues);

--- a/app/src/main/java/com/nitramite/apcupsdmonitor/UpsEditor.java
+++ b/app/src/main/java/com/nitramite/apcupsdmonitor/UpsEditor.java
@@ -162,7 +162,7 @@ public class UpsEditor extends AppCompatActivity {
             privateKeyPassphraseET.setText(ups.UPS_PRIVATE_KEY_PASSWORD);
             strictHostKeyCheckingSwitch.setChecked(ups.UPS_SERVER_SSH_STRICT_HOST_KEY_CHECKING.equals("1"));
             statusCommandET.setText(ups.UPS_SERVER_STATUS_COMMAND);
-            isApcNmc = ups.IS_APC_NMC;
+            isApcNmc = ups.UPS_IS_APC_NMC;
             if (isApcNmc) {
                 int pos = dataAdapter.getPosition(getString(R.string.apc_network_management_card_aos));
                 cmdPresetSelection.setSelection(pos);
@@ -207,7 +207,7 @@ public class UpsEditor extends AppCompatActivity {
             contentValues.put(DatabaseHelper.UPS_PRIVATE_KEY_PATH, privateKeyLocationET.getText().toString());
             contentValues.put(DatabaseHelper.UPS_SERVER_SSH_STRICT_HOST_KEY_CHECKING, strictHostKeyCheckingSwitch.isChecked() ? "1" : "0");
             contentValues.put(DatabaseHelper.UPS_SERVER_STATUS_COMMAND, statusCommandET.getText().toString());
-            contentValues.put(DatabaseHelper.IS_APC_NMC, isApcNmc);
+            contentValues.put(DatabaseHelper.UPS_IS_APC_NMC, isApcNmc);
             contentValues.put(DatabaseHelper.UPS_SERVER_EVENTS_LOCATION, eventsLocationET.getText().toString());
             contentValues.put(DatabaseHelper.UPS_LOAD_EVENTS, loadUpsEventsSwitch.isChecked() ? "1" : "0");
             databaseHelper.insertUpdateUps(upsId, contentValues);


### PR DESCRIPTION
This adds a ConnectorTask#getUPSStatusNMC method as an alternative for getUPSStatusSSH to use when connecting to an APC NMC card. The difference is that is new method will open a full SSH shell connection to read the status, since `exec` doesn't seem to work.

Fixes #25 

I haven't currently implemented it, but this same method could also be used to read the events log through the `eventlog` command. The event parsing/display logic would need some tweaking to strip out the headers etc though.