### PR TITLE
Add missing background colour in theme

### DIFF
--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -9,6 +9,7 @@
         <item name="android:statusBarColor">@color/colorPrimaryDark</item>
         <item name="android:itemBackground">@color/color_white</item>
         <item name="android:actionMenuTextColor">@color/black</item>
+        <item name="eventsTextBackgroundColor">@color/materialGray</item>
     </style>
 
     <style name="AppTheme.NoActionBar">


### PR DESCRIPTION
App crashed with light theme because of this.

![image](https://user-images.githubusercontent.com/55850510/138515801-8c477178-d279-4e88-b72f-361c42d1d36d.png)
