### PR TITLE
Revert "Bump appcompat from 1.3.1 to 1.4.0"

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar','*.aar'])
     implementation group: 'com.jcraft', name: 'jsch', version: '0.1.55'
     // AndroidX
-    implementation 'androidx.appcompat:appcompat:1.4.0'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'androidx.preference:preference:1.1.1'


### PR DESCRIPTION
Reverts norkator/apcupsd-monitor#89

apparently there was an issue with this version